### PR TITLE
IPAM: recycle the IP-unused eni in IPRelease handling

### DIFF
--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -89,6 +89,10 @@ func (n *Node) PopulateStatusFields(resource *v2.CiliumNode) {
 		})
 }
 
+func (n *Node) ReleaseInterface(ctx context.Context, release *ipam.ReleaseAction, scopedLog *logrus.Entry) (string, error) {
+	return "", nil
+}
+
 // CreateInterface creates an additional interface with the instance and
 // attaches it to the instance as specified by the CiliumNode. neededAddresses
 // of secondary IPs are assigned to the interface up to the maximum number of

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -533,6 +533,10 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 	return toAllocate, "", nil
 }
 
+func (n *Node) ReleaseInterface(ctx context.Context, release *ipam.ReleaseAction, scopedLog *logrus.Entry) (string, error) {
+	return "", nil
+}
+
 // ResyncInterfacesAndIPs is called to retrieve and ENIs and IPs as known to
 // the EC2 API and return them
 func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -136,6 +136,10 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 	return 0, "", fmt.Errorf("not implemented")
 }
 
+func (n *Node) ReleaseInterface(ctx context.Context, release *ipam.ReleaseAction, scopedLog *logrus.Entry) (string, error) {
+	return "", nil
+}
+
 // ResyncInterfacesAndIPs is called to retrieve interfaces and IPs known
 // to the Azure API and return them
 func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -18,6 +18,7 @@ type prometheusMetrics struct {
 	Allocation           *prometheus.HistogramVec
 	Release              *prometheus.HistogramVec
 	AllocateInterfaceOps *prometheus.CounterVec
+	ReleaseInterfaceOps  *prometheus.CounterVec
 	AllocateIpOps        *prometheus.CounterVec
 	ReleaseIpOps         *prometheus.CounterVec
 	AvailableIPs         *prometheus.GaugeVec
@@ -95,6 +96,13 @@ func NewPrometheusMetrics(namespace string, registry metrics.RegisterGatherer) *
 		Subsystem: ipamSubsystem,
 		Name:      "interface_creation_ops",
 		Help:      "Number of interfaces allocated",
+	}, []string{"subnet_id"})
+
+	m.ReleaseInterfaceOps = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: ipamSubsystem,
+		Name:      "interface_deletion_ops",
+		Help:      "Numbers of interfaces released",
 	}, []string{"subnet_id"})
 
 	m.AvailableInterfaces = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -175,6 +183,7 @@ func NewPrometheusMetrics(namespace string, registry metrics.RegisterGatherer) *
 	registry.MustRegister(m.AllocateIpOps)
 	registry.MustRegister(m.ReleaseIpOps)
 	registry.MustRegister(m.AllocateInterfaceOps)
+	registry.MustRegister(m.ReleaseInterfaceOps)
 	registry.MustRegister(m.AvailableInterfaces)
 	registry.MustRegister(m.InterfaceCandidates)
 	registry.MustRegister(m.EmptyInterfaceSlots)
@@ -204,6 +213,10 @@ func (p *prometheusMetrics) ResyncTrigger() trigger.MetricsObserver {
 
 func (p *prometheusMetrics) IncInterfaceAllocation(subnetID string) {
 	p.AllocateInterfaceOps.WithLabelValues(subnetID).Inc()
+}
+
+func (p *prometheusMetrics) IncInterfaceRelease(subnetID string) {
+	p.ReleaseInterfaceOps.WithLabelValues(subnetID).Inc()
 }
 
 func (p *prometheusMetrics) AddIPAllocation(subnetID string, allocated int64) {
@@ -342,6 +355,7 @@ type NoOpMetrics struct{}
 func (m *NoOpMetrics) AllocationAttempt(typ, status, subnetID string, observe float64)           {}
 func (m *NoOpMetrics) ReleaseAttempt(typ, status, subnetID string, observe float64)              {}
 func (m *NoOpMetrics) IncInterfaceAllocation(subnetID string)                                    {}
+func (m *NoOpMetrics) IncInterfaceRelease(subnetID string)                                       {}
 func (m *NoOpMetrics) AddIPAllocation(subnetID string, allocated int64)                          {}
 func (m *NoOpMetrics) AddIPRelease(subnetID string, released int64)                              {}
 func (m *NoOpMetrics) SetAllocatedIPs(typ string, allocated int)                                 {}

--- a/pkg/ipam/metrics/mock/mock.go
+++ b/pkg/ipam/metrics/mock/mock.go
@@ -17,6 +17,7 @@ type mockMetrics struct {
 	ipAllocations         map[string]int64
 	ipReleases            map[string]int64
 	interfaceAllocations  map[string]int64
+	interfaceReleases     map[string]int64
 	allocatedIPs          map[string]int
 	availableInterfaces   int
 	interfaceCandidates   int
@@ -80,6 +81,12 @@ func (m *mockMetrics) ReleaseAttempt(typ, status, subnetID string, observer floa
 func (m *mockMetrics) IncInterfaceAllocation(subnetID string) {
 	m.mutex.Lock()
 	m.interfaceAllocations[fmt.Sprintf("subnetId=%s", subnetID)]++
+	m.mutex.Unlock()
+}
+
+func (m *mockMetrics) IncInterfaceRelease(subnetID string) {
+	m.mutex.Lock()
+	m.interfaceReleases[fmt.Sprintf("subnetId=%s", subnetID)]++
 	m.mutex.Unlock()
 }
 

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -35,7 +35,7 @@ const (
 
 	// allocation type
 	createInterfaceAndAllocateIP = "createInterfaceAndAllocateIP"
-	releaseInterfaceAndRecycleIP = "releaseInterfaceAndRecycleIP"
+	deleteInterfaceAndReleaseIP  = "deleteInterfaceAndReleaseIP"
 	allocateIP                   = "allocateIP"
 	releaseIP                    = "releaseIP"
 
@@ -558,7 +558,7 @@ func (n *Node) releaseInterface(ctx context.Context, r *ReleaseAction) (released
 	if len(errCondition) > 0 {
 		status = errCondition
 	}
-	n.manager.metricsAPI.ReleaseAttempt(releaseInterfaceAndRecycleIP, status, string(r.PoolID), metrics.SinceInSeconds(start))
+	n.manager.metricsAPI.ReleaseAttempt(deleteInterfaceAndReleaseIP, status, string(r.PoolID), metrics.SinceInSeconds(start))
 	if err != nil {
 		scopedLog.Warningf("Unable to release interface on instance: %s", err)
 		return false, err

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -59,6 +59,10 @@ type NodeOperations interface {
 	// AllocationAction.MaxIPsToAllocate.
 	CreateInterface(ctx context.Context, allocation *AllocationAction, scopedLog *logrus.Entry) (int, string, error)
 
+	// ReleaseInterface is called to release an IP-unused interface. This is only
+	// done if PrepareIPRelease indicates that all IPs are not used on this interface.
+	ReleaseInterface(ctx context.Context, r *ReleaseAction, scopedLog *logrus.Entry) (string, error)
+
 	// ResyncInterfacesAndIPs is called to synchronize the latest list of
 	// interfaces and IPs associated with the node. This function is called
 	// sparingly as this information is kept in sync based on the success
@@ -139,6 +143,7 @@ type MetricsAPI interface {
 	AllocationAttempt(typ, status, subnetID string, observe float64)
 	ReleaseAttempt(typ, status, subnetID string, observe float64)
 	IncInterfaceAllocation(subnetID string)
+	IncInterfaceRelease(subnetID string)
 	AddIPAllocation(subnetID string, allocated int64)
 	AddIPRelease(subnetID string, released int64)
 	SetAllocatedIPs(typ string, allocated int)

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -90,6 +90,10 @@ func (n *nodeOperationsMock) CreateInterface(ctx context.Context, allocation *Al
 	return 0, "operation not supported", fmt.Errorf("operation not supported")
 }
 
+func (n *nodeOperationsMock) ReleaseInterface(ctx context.Context, release *ReleaseAction, scopedLog *logrus.Entry) (string, error) {
+	return "operation not supported", fmt.Errorf("operation not supported")
+}
+
 func (n *nodeOperationsMock) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (
 	ipamTypes.AllocationMap,
 	ipamStats.InterfaceStats,

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -209,6 +209,16 @@ type IPAMStatus struct {
 	ReleaseIPs map[string]IPReleaseStatus `json:"release-ips,omitempty"`
 }
 
+// IsResourceUsing judge the given interface id whether are using on this node
+func (s *IPAMStatus) IsResourceUsing(eniID string) bool {
+	for _, allocation := range s.Used {
+		if allocation.Owner == eniID {
+			return true
+		}
+	}
+	return false
+}
+
 // IPAMPoolRequest is a request from the agent to the operator, indicating how
 // may IPs it requires from a given pool
 type IPAMPoolDemand struct {
@@ -535,6 +545,16 @@ func (m *InstanceMap) GetInterface(instanceID, interfaceID string) (InterfaceRev
 	}
 
 	return InterfaceRevision{}, false
+}
+
+// DeleteInterface will delete the interface on the instance.
+func (m *InstanceMap) DeleteInterface(instanceID string, interfaceID string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if instance := m.data[instanceID]; instance != nil {
+		delete(instance.Interfaces, interfaceID)
+	}
 }
 
 // DeepCopy returns a deep copy

--- a/pkg/volcengine/eni/instances.go
+++ b/pkg/volcengine/eni/instances.go
@@ -166,6 +166,15 @@ func (m *InstancesManager) UpdateENI(instanceID string, eni *eniTypes.ENI) {
 	m.instances.Update(instanceID, eniRevision)
 }
 
+// DeleteENI deletes the ENI definition for the given instance. If the ENI
+// is not present, it will do nothing.
+func (m *InstancesManager) DeleteENI(instanceID string, eniID string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	m.instances.DeleteInterface(instanceID, eniID)
+}
+
 // ForeachInstance will iterate over each instance inside `instances`, and call
 // `fn`. This function is read-locked for the entire execution.
 func (m *InstancesManager) ForeachInstance(instanceID string, fn ipamTypes.InterfaceIterator) {


### PR DESCRIPTION
1. add ReleaseInterface On NodeOperations that represents releasing interface action if needed when handling ip release
2. add metrics for release interface static and report at prometheus metric
3. fully implementation for volcengine CRD Operator: will detect whether is the last private ips release for current interface in every ip release procedure, and then delete the interface which have no any private IPs used if so

Signed-off-by: Jinzhu Lee <lijinzhu.azl@bytedance.com>